### PR TITLE
fix #51 - Improve Bridge-gui devops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@ WORKDIR /opt/metadisk-gui
 COPY . /opt/metadisk-gui/
 RUN /opt/metadisk-gui/scripts/install_deps_debian.sh
 # Need to clean node_modules dir here or exclude it
+# RUN rm -rf /opt/metadisk-gui/node_modules
 RUN npm install
 # Build the app
-RUN npm run build
+# RUN npm run build
 
 # Expose listen port
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,12 @@ WORKDIR /opt/metadisk-gui
 # Copy over the app and install
 COPY . /opt/metadisk-gui/
 RUN /opt/metadisk-gui/scripts/install_deps_debian.sh
-# Need to clean node_modules dir here or exclude it
-# RUN rm -rf /opt/metadisk-gui/node_modules
-RUN npm install
-# Build the app
-# RUN npm run build
+
+# Clean remove node_modules copied from host
+RUN rm -rf /opt/metadisk-gui/node_modules
+
+# Install node modules for production (i.e. don't install devdeps)
+RUN npm install --production
 
 # Expose listen port
 EXPOSE 8080

--- a/bin/server.js
+++ b/bin/server.js
@@ -9,7 +9,7 @@ global.__DISABLE_SSR__ = true;  // <----- DISABLES SERVER SIDE RENDERING FOR ERR
 global.__DEVELOPMENT__ = process.env.NODE_ENV !== 'production';
 
 if (__DEVELOPMENT__) {
-  console.log(`RUNNING IN DEVELOPMENT`);
+  console.log('RUNNING IN DEVELOPMENT');
   return require('../webpack/webpack-dev-server');
 }
 

--- a/bin/server.js
+++ b/bin/server.js
@@ -1,31 +1,45 @@
 #!/usr/bin/env node
-require('../server.babel'); // babel registration (runtime transpilation for node)
-/**
- * Define isomorphic constants.
+
+/*
+ * CHECK NODE VERSION!
  */
-global.__CLIENT__ = false;
-global.__SERVER__ = true;
-global.__DISABLE_SSR__ = true;  // <----- DISABLES SERVER SIDE RENDERING FOR ERROR DEBUGGING
-global.__DEVELOPMENT__ = process.env.NODE_ENV !== 'production';
+var fs = require('fs');
+var path = require('path');
+var currentNodeVersion = process.versions.node;
+var wantedNodeVersion = fs.readFileSync(path.resolve(__dirname, '../.nvmrc')).toString();
+var wantedRegex = (new RegExp('^' + wantedNodeVersion.match(/^(\d+)\./)[1]));
 
-if (__DEVELOPMENT__) {
-  console.log('RUNNING IN DEVELOPMENT');
-  return require('../webpack/webpack-dev-server');
+if (!wantedRegex.test(currentNodeVersion)) {
+  console.error('Your current node version is %s. Please use a version that is semver compatible with ^%s', currentNodeVersion, wantedNodeVersion)
+} else {
+  require('../server.babel'); // babel registration (runtime transpilation for node)
+  /**
+   * Define isomorphic constants.
+   */
+  global.__CLIENT__ = false;
+  global.__SERVER__ = true;
+  global.__DISABLE_SSR__ = true;  // <----- DISABLES SERVER SIDE RENDERING FOR ERROR DEBUGGING
+  global.__DEVELOPMENT__ = process.env.NODE_ENV !== 'production';
+
+  if (__DEVELOPMENT__) {
+    console.log('RUNNING IN DEVELOPMENT');
+    require('../webpack/webpack-dev-server');
+  } else {
+    var webpack = require('webpack');
+    var webpackConfig = require('../webpack/prod.config');
+
+    var compiler = webpack(webpackConfig);
+
+    compiler.run(function (err, stats) {
+      if (err) return console.error(err);
+
+      var parseAssets = require('./parseAssets');
+      var assets = parseAssets(stats, compiler.options);
+
+      global.assets = assets.main;
+
+      require('../src/server');
+    });
+  }
 }
-
-var webpack = require('webpack');
-var webpackConfig = require('../webpack/prod.config');
-
-var compiler = webpack(webpackConfig);
-
-compiler.run(function (err, stats) {
-  if (err) return console.error(err);
-
-  var parseAssets = require('./parseAssets');
-  var assets = parseAssets(stats, compiler.options);
-
-  global.assets = assets.main;
-
-  require('../src/server');
-});
 

--- a/package.json
+++ b/package.json
@@ -13,11 +13,10 @@
     "start": "concurrent --kill-others \"npm run start-prod\" \"npm run start-prod-api\"",
     "start-prod": "better-npm-run start-prod",
     "build": "webpack --verbose --colors --display-error-details --config webpack/prod.config.js",
-    "postinstall": "webpack --display-error-details --config webpack/prod.config.js",
     "lint": "eslint -c .eslintrc src api",
     "start-dev": "better-npm-run start-dev",
-    "watch-client": "better-npm-run watch-client",
-    "dev": "concurrent --kill-others \"npm run watch-client\" \"npm run start-dev\" \"npm run start-dev-api\"",
+    "watch-client": "better-npm-run start-dev",
+    "dev": "concurrent --kill-others \"npm run start-dev\" \"npm run start-dev-api\"",
     "test": "karma start",
     "test-node": "./node_modules/mocha/bin/mocha $(find api -name '*-test.js') --compilers js:babel-core/register",
     "test-node-watch": "./node_modules/mocha/bin/mocha $(find api -name '*-test.js') --compilers js:babel-core/register --watch"
@@ -41,13 +40,6 @@
         "APIPORT": 3030
       }
     },
-    "watch-client": {
-      "command": "babel-node webpack/webpack-dev-server.js",
-      "env": {
-        "UV_THREADPOOL_SIZE": 100,
-        "NODE_PATH": "./src"
-      }
-    }
   },
   "dependencies": {
     "async": "^2.0.0-rc.2",
@@ -110,13 +102,15 @@
     "mocha": "^2.3.3",
     "phantomjs": "^1.9.18",
     "phantomjs-polyfill": "0.0.1",
+    "react-hot-loader": "^1.3.0",
     "react-transform-catch-errors": "^1.0.0",
-    "redbox-react": "^1.1.1",
+    "redbox-react": "1.1.1",
     "redux-devtools": "^3.0.0-beta-3",
     "redux-devtools-dock-monitor": "^1.0.0-beta-3",
     "redux-devtools-log-monitor": "^1.0.0-beta-3",
     "sinon": "^1.17.2",
     "webpack-dev-middleware": "^1.4.0",
+    "webpack-dev-server": "^1.14.1",
     "webpack-hot-middleware": "^2.5.0"
   },
   "engines": {

--- a/scripts/node_setup.sh
+++ b/scripts/node_setup.sh
@@ -8,9 +8,9 @@
 #
 # Run as root or insert `sudo -E` before `bash`:
 #
-# curl -sL https://deb.nodesource.com/setup_0.12 | bash -
+# curl -sL https://deb.nodesource.com/setup_4.x | bash -
 #   or
-# wget -qO- https://deb.nodesource.com/setup_0.12 | bash -
+# wget -qO- https://deb.nodesource.com/setup_4.x | bash -
 #
 
 export DEBIAN_FRONTEND=noninteractive
@@ -36,7 +36,7 @@ exec_cmd() {
 }
 
 
-print_status "Installing the NodeSource Node.js 0.12 repo..."
+print_status "Installing the NodeSource Node.js 4.x repo..."
 
 
 PRE_INSTALL_PKGS=""
@@ -107,10 +107,10 @@ fi
 print_status "Confirming \"${DISTRO}\" is supported..."
 
 if [ -x /usr/bin/curl ]; then
-    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node_0.12/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "curl -sLf -o /dev/null 'https://deb.nodesource.com/node_4.x/dists/${DISTRO}/Release'"
     RC=$?
 else
-    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node_0.12/dists/${DISTRO}/Release'"
+    exec_cmd_nobail "wget -qO /dev/null -o /dev/null 'https://deb.nodesource.com/node_4.x/dists/${DISTRO}/Release'"
     RC=$?
 fi
 
@@ -134,13 +134,13 @@ else
     exec_cmd 'wget -qO- https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -'
 fi
 
-print_status 'Creating apt sources list file for the NodeSource Node.js 0.12 repo...'
+print_status 'Creating apt sources list file for the NodeSource Node.js 4.x repo...'
 
-exec_cmd "echo 'deb https://deb.nodesource.com/node_0.12 ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
-exec_cmd "echo 'deb-src https://deb.nodesource.com/node_0.12 ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb https://deb.nodesource.com/node_4.x ${DISTRO} main' > /etc/apt/sources.list.d/nodesource.list"
+exec_cmd "echo 'deb-src https://deb.nodesource.com/node_4.x ${DISTRO} main' >> /etc/apt/sources.list.d/nodesource.list"
 
 print_status 'Running `apt-get update` for you...'
 
 exec_cmd 'apt-get update'
 
-print_status 'Run `apt-get install nodejs` (as root) to install Node.js 0.12 and npm'
+print_status 'Run `apt-get install nodejs` (as root) to install Node.js 4.x and npm'

--- a/src/config.js
+++ b/src/config.js
@@ -9,9 +9,9 @@ const environment = {
 
 module.exports = Object.assign({
   host: process.env.HOST || '127.0.0.1',
-  port: process.env.PORT || 8080,
+  port: Number(process.env.PORT) || 8080,
   apiHost: process.env.APIHOST || 'api.storj.io',
-  apiPort: process.env.APIPORT || 6500,
+  apiPort: Number(process.env.APIPORT) || 6500,
   apiProtocol: 'http://', //(process.env.NODE_ENV === 'development') ? 'http://' : 'https://',
   app: {
     title: 'Storj',

--- a/src/helpers/Html.js
+++ b/src/helpers/Html.js
@@ -42,7 +42,7 @@ export default class Html extends Component {
           {/* outputs a <style/> tag with all bootstrap styles + App.scss + it could be CurrentPage.scss. */}
           {/* can smoothen the initial style flash (flicker) on page load in development mode. */}
           {/* ideally one could also include here the style for the current page (Home.scss, About.scss, etc) */}
-          { Object.keys(assets.css).length === 0 ? <style dangerouslySetInnerHTML={{__html: require('../theme/bootstrap.config.js') + require('../containers/App/App.scss')._style}}/> : null }
+          {/* Object.keys(assets.css).length === 0 ? <style dangerouslySetInnerHTML={{__html: require('../theme/bootstrap.config.js') + require('../containers/App/App.scss')._style}}/> : null */}
         </head>
         <body>
           <div id="content" dangerouslySetInnerHTML={{__html: content}}/>

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -1,7 +1,6 @@
 // Webpack config for creating the production bundle.
 var path = require('path');
 var webpack = require('webpack');
-var CleanPlugin = require('clean-webpack-plugin');
 var ExtractTextPlugin = require('extract-text-webpack-plugin');
 var strip = require('strip-loader');
 
@@ -64,8 +63,6 @@ module.exports = {
     tls: 'empty'
   },
   plugins: [
-    new CleanPlugin([path.join(__dirname, relativeAssetsPath, '**/*')], {root: process.cwd()}),
-
     // css files from the extract-text-plugin loader
     new ExtractTextPlugin('[name].css', {allChunks: true}),
     new webpack.DefinePlugin({

--- a/webpack/webpack-dev-server.js
+++ b/webpack/webpack-dev-server.js
@@ -20,7 +20,6 @@ const serverOptions = {
   quiet: true,
   noInfo: true,
   hot: true,
-  inline: true,
   lazy: false,
   publicPath: webpackConfig.output.publicPath,
   headers: {'Access-Control-Allow-Origin': '*'},
@@ -44,8 +43,8 @@ app
     res.send('<!doctype html>\n' +
       ReactDOM.renderToString(React.createElement(Html, {
         assets: {
-          js: {main: '/dist/main.js'},
-          css: {main: '/dist/main.css'}
+          js: '/dist/main.js',
+          css: '/dist/main.css'
         }
       })));
   })


### PR DESCRIPTION
#### `CleanWebpack` plugin not doing it's job:

Used to get "<path> is outside of project root. Skipping..." message

#### `webpack-isomorphic-tools` aren't really necessary

We're only doing partial server-side rendering of the index document. For this `webpack-isomorphic-tools` is unnecessary and adds additional configuration complexity.

#### `webpack-dev-middleware` and `webpack-hot-middleware` add unnecessary complexity

`webpack-dev-server` sits on top of express and can be used instead of `webpack-dev-middleware` and `webpack-hot-middleware`, as those middleware add additional configuration complexity as well as additional dependencies.

#### Docker tweaks

* comment out `RUN npm build` step in docker file as it's currently not needed (we may want to change this - needs discussion)
* fix possible es6/es5 issue in bin/server.js