### PR TITLE
Fix windows+git+.sh scripts - actually

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
use .gitattributes instead of ansible task to ensure .sh files are executable when `git`ing on windows: thanks @wilbown