### PR TITLE
Add banners for both regular user and referred user

### DIFF
--- a/src/components/auth/new-referral-user-banner.js
+++ b/src/components/auth/new-referral-user-banner.js
@@ -12,7 +12,7 @@ export default class NewReferralUserBanner extends Component {
             <p><strong>Referral Bonus!</strong></p>
 
             <p>
-              Your friend has given you <b>$10 of free credits</b>, valid for
+              Your friend has given you a <b>$10 credit</b>, valid for
               the next three months!
             </p>
             <p>

--- a/src/components/auth/new-referral-user-banner.js
+++ b/src/components/auth/new-referral-user-banner.js
@@ -1,0 +1,27 @@
+import React, { Component } from 'react';
+
+export default class NewReferralUserBanner extends Component {
+  render() {
+    return (
+      <div
+          className="alert alert-info text-center"
+          role="alert"
+          dataAlertcookie="alert_new_user_referral"
+        >
+          <span>
+            <p><strong>Referral Bonus!</strong></p>
+
+            <p>
+              Your friend has given you <b>50GB of free storage
+              and bandwidth</b> for the next three months!
+            </p>
+            <p>
+              Plus, you'll get our new user bonus: one year
+              of free service — up to 25GB of storage and
+              bandwidth every month!
+            </p>
+          </span>
+        </div>
+    )
+  }
+}

--- a/src/components/auth/new-referral-user-banner.js
+++ b/src/components/auth/new-referral-user-banner.js
@@ -12,8 +12,8 @@ export default class NewReferralUserBanner extends Component {
             <p><strong>Referral Bonus!</strong></p>
 
             <p>
-              Your friend has given you <b>50GB of free storage
-              and bandwidth</b> for the next three months!
+              Your friend has given you <b>$10 of free credits</b>, valid for
+              the next three months!
             </p>
             <p>
               Plus, you'll get our new user bonus: one year

--- a/src/components/auth/new-user-banner.js
+++ b/src/components/auth/new-user-banner.js
@@ -1,0 +1,22 @@
+import React, { Component } from 'react';
+
+export default class NewUserBanner extends Component {
+  render() {
+    return (
+      <div
+          className="alert alert-info text-center"
+          role="alert"
+          dataAlertcookie="alert_new_user"
+      >
+        <span>
+          <p><strong>New User Bonus!</strong></p>
+          <p>
+            Sign up now to unlock <b>one year of free
+            service</b> — up to 25GB of storage and bandwidth
+            every month!
+          </p>
+        </span>
+      </div>
+    )
+  }
+}

--- a/src/containers/auth/signup-form/index.js
+++ b/src/containers/auth/signup-form/index.js
@@ -39,7 +39,6 @@ export default class SignUpForm extends Component {
   };
 
   componentWillMount() {
-    console.log('this prooooops', this.props);
     if (this.props.location.query.referralLink) {
       this.setState({ showReferralBanner: true });
     } else {

--- a/src/containers/auth/signup-form/index.js
+++ b/src/containers/auth/signup-form/index.js
@@ -71,14 +71,15 @@ export default class SignUpForm extends Component {
       client.api.createUser(credentials).then((result) => {
         if (result.error) {
           return reject({ _error: result.error })
-        } else {
-          axios.post(BILLING_URL + '/credits/signups', referral)
-            .then((res) => {
-              hashHistory.push('/signup-success');
-              return resolve(res);
-            })
-            .catch((err) => console.error(err));
         }
+
+        axios.post(BILLING_URL + '/credits/signups', referral)
+          .then((res) => {
+            hashHistory.push('/signup-success');
+            return resolve(res);
+          })
+          .catch((err) => console.error(err));
+
       }, (err) => {
         if (err && err.message) {
           reject({_error: err.message});

--- a/src/containers/auth/signup-form/index.js
+++ b/src/containers/auth/signup-form/index.js
@@ -6,6 +6,8 @@ import client from 'utils/api-client';
 import signupValidation from 'containers/auth/signup-form/signup-validation';
 import formLabelError from 'components/error-views/form-label-error';
 import TermsOfService from 'components/copy/terms-of-service';
+import NewReferralUserBanner from 'components/auth/new-referral-user-banner';
+import NewUserBanner from 'components/auth/new-user-banner';
 import { connect } from 'react-apollo';
 import gql from 'graphql-tag';
 import Promise from 'bluebird';
@@ -30,10 +32,20 @@ export default class SignUpForm extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      showEula: false
+      showEula: false,
+      showReferralBanner: false
     };
     this.submit = this.submit.bind(this);
-  }
+  };
+
+  componentWillMount() {
+    console.log('this prooooops', this.props);
+    if (this.props.location.query.referralLink) {
+      this.setState({ showReferralBanner: true });
+    } else {
+      this.setState({ showReferralBanner: false });
+    }
+   };
 
   openEula(event) {
     event.preventDefault();
@@ -103,6 +115,12 @@ export default class SignUpForm extends Component {
                 <div className="content">
 
                   <h1 className="title text-center form-group">Sign Up</h1>
+
+                  {
+                    this.state.showReferralBanner
+                    ? <NewReferralUserBanner></NewReferralUserBanner>
+                    : <NewUserBanner></NewUserBanner>
+                  }
 
                   <form>
 


### PR DESCRIPTION
Add a little razzle-dazzle-pizzaz to the sign up page. Let's users know what sign up credits they are getting. Regular users see 25GB/25GB for a year, and referred users see 50GB/50GB for three months + 25GB/25GB for a year.

Related: https://github.com/Storj/service-storage-models/pull/82 and https://github.com/Storj/billing/pull/38