### PR TITLE
fix transaction description interpolation for debits (bandwidth vs storage)

### DIFF
--- a/src/containers/billing/index.js
+++ b/src/containers/billing/index.js
@@ -294,14 +294,16 @@ export default class Billing extends Component {
        * Converts bytes to gigabytes
        */
       if (debit.type === 'storage' || debit.type === 'bandwidth') {
-        amountUsed = roundToGBAmount(debit[debit.type], 'bytes');
+        const amount = debit[debit.type];
+        amountUsed = debit.type === 'bandwidth' ? roundToGBAmount(amount, 'bytes') : amount;
       }
 
       const transaction = {...debit};
+      const unit = debit.type === 'bandwidth' ? 'GB' : 'GBhr';
 
       transaction.description =
         amountUsed
-        ? `${amountUsed} GB of ${debit.type} used`
+        ? `${amountUsed} ${unit} of ${debit.type} used`
         : `Adjustment of ${debit.amount}`;
       transaction.timestamp = Date.parse(debit.created);
       transaction.created = `${moment.utc((debit.created))


### PR DESCRIPTION
* Switches the unit between `GB` and `GBhr` for bandwidth and storage debits respectively
* Fixes rounding issue for storage debits

![screen shot 2017-04-27 at 11 23 00 pm](https://cloud.githubusercontent.com/assets/600733/25505209/1c4cc3aa-2ba1-11e7-96ea-470b8a6aed05.png)
