### PR TITLE
Billing UI enhancements

### DIFF
--- a/src/components/billing/transactions-list.js
+++ b/src/components/billing/transactions-list.js
@@ -32,6 +32,12 @@ const TransactionsList = ({ transactions }) => {
                             </td>
                             <td>
                               {transaction.description}
+                              {!transaction.descriptionSub ? <span></span> :
+                                <span>
+                                  <br />
+                                  <sub>{transaction.descriptionSub}</sub>
+                                </span>
+                              }
                             </td>
                             <td>
                               <span className={isNegative ? 'text-success' : ''}>

--- a/src/components/billing/usage-panel.js
+++ b/src/components/billing/usage-panel.js
@@ -15,7 +15,8 @@ const UsagePanel = ({ storage, bandwidth }) => {
               <h2 className="mb0 blue unit-numbers">
                 <b>{storage || '0.00'}</b>
                 <div className="text-muted unit-text">
-                  <div> / 25GB<sub>/mo.</sub></div>
+                  {/* TODO: add tooltip here explaining unit or something */}
+                  <div> / 25GB<sub>mo.</sub></div>
                   <div>free</div>
                 </div>
               </h2>

--- a/src/components/billing/usage-panel.js
+++ b/src/components/billing/usage-panel.js
@@ -15,7 +15,7 @@ const UsagePanel = ({ storage, bandwidth }) => {
               <h2 className="mb0 blue unit-numbers">
                 <b>{storage || '0.00'}</b>
                 <div className="text-muted unit-text">
-                  <div> / 25GB</div>
+                  <div> / 25GB<sub>/mo.</sub></div>
                   <div>free</div>
                 </div>
               </h2>

--- a/src/components/billing/usage-panel.scss
+++ b/src/components/billing/usage-panel.scss
@@ -9,3 +9,7 @@
   letter-spacing: 0;
   display: inline-block;
 }
+
+.unit-text sub {
+  vertical-align: top;
+}

--- a/src/containers/billing/index.js
+++ b/src/containers/billing/index.js
@@ -294,14 +294,16 @@ export default class Billing extends Component {
        * Converts bytes to gigabytes
        */
       if (debit.type === 'storage' || debit.type === 'bandwidth') {
-        amountUsed = roundToGBAmount(debit[debit.type], 'bytes');
+        const amount = debit[debit.type];
+        amountUsed = debit.type === 'bandwidth' ? roundToGBAmount(amount, 'bytes') : amount;
       }
 
       const transaction = {...debit};
+      const unit = debit.type === 'bandwidth' ? 'GB' : 'GBhr';
 
       transaction.description =
         amountUsed
-        ? `${amountUsed} GB of ${debit.type} used`
+        ? `${amountUsed} ${unit} of ${debit.type} used`
         : `Adjustment of ${debit.amount}`;
       transaction.timestamp = Date.parse(debit.created);
       transaction.created = `${moment.utc((debit.created))

--- a/src/containers/billing/index.js
+++ b/src/containers/billing/index.js
@@ -174,9 +174,7 @@ export default class Billing extends Component {
 
       // Set Storage
       const storage = this.getSum(debits, 'storage');
-      const storageInGB = roundToGBAmount(storage, 'bytes');
-      const averageStorage = this.getAverage(storageInGB, debits.length);
-      const prettyStorage = setToTwoDecimalPlaces(averageStorage);
+      const prettyStorage = setToTwoDecimalPlaces(storage / 703);
       this.props.setStorage(prettyStorage !== 'NaN' ? prettyStorage : '0.00');
 
       // Set Bandwidth
@@ -294,12 +292,18 @@ export default class Billing extends Component {
        * Converts bytes to gigabytes
        */
       if (debit.type === 'storage' || debit.type === 'bandwidth') {
-        const amount = debit[debit.type];
-        amountUsed = debit.type === 'bandwidth' ? roundToGBAmount(amount, 'bytes') : amount;
+        const size = debit[debit.type];
+        amountUsed = debit.type === 'bandwidth' ? roundToGBAmount(size, 'bytes') : size;
       }
 
       const transaction = {...debit};
       const unit = debit.type === 'bandwidth' ? 'GB' : 'GBhr';
+
+      if (debit.type === 'storage' && amountUsed > 0) {
+        // NB: `703` is the average number of hours in a year
+        const sizeGbPerMo = amountUsed / 703;
+        transaction.descriptionSub = `(${roundToGBAmount(sizeGbPerMo)}GB/month)`
+      }
 
       transaction.description =
         amountUsed

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,9 +13,8 @@ export function roundToGBAmount(num, type) {
   const modNum = setToTwoDecimalPlaces(numInGB);
 
   // Checks to see if the amount is less than one cent
-  if (modNum.indexOf('0.00') === 0) {
-    const lessThanOneCent = '< 0.01';
-    return lessThanOneCent;
+  if (String(modNum).indexOf('0.00') === 0) {
+    return '< 0.01';
   }
   return `${modNum}`;
 }


### PR DESCRIPTION
* Added `mo.` in the usage panel for storage for proper unit conversion
* Added a `descriptionSub` area in the transaction-list
* Populate `descriptionSub` if a debit is of type `storage` and has an `amount` > 0 with a GB/mo. conversion for consistency with usage panel

![screen shot 2017-04-28 at 12 52 50 am](https://cloud.githubusercontent.com/assets/600733/25507584/33816222-2bad-11e7-8861-7291e7611d1f.png)

### UPDATE: Usage Panel
<img width="501" alt="screen shot 2017-04-28 at 4 11 28 am" src="https://cloud.githubusercontent.com/assets/600733/25511911/69397ffe-2bca-11e7-9d68-b9efb3b0d703.png">
