### PR TITLE
fix bridge-gui-vue url

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Storj Bridge GUI - *DEPRECATED*
 ================
 
 ## This repo is deprecated. 
-### Please use [bridge-gui-vue](https://github.com/Storj/bridge-gui.vue-git) instead. 
+### Please use [bridge-gui-vue](https://github.com/Storj/bridge-gui-vue.git) instead. 
 
 ### This repo will not be maintained or updated. 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Storj Bridge GUI - *DEPRECATED*
 ================
 
 ## This repo is deprecated. 
-### Please use [bridge-gui-vue](https://github.com/Storj/bridge-gui.vue.git) instead. 
+### Please use [bridge-gui-vue](https://github.com/Storj/bridge-gui.vue-git) instead. 
 
 ### This repo will not be maintained or updated. 
 


### PR DESCRIPTION
This was pointed out in rocket chat's #dev by @Pretender.